### PR TITLE
Implement header guard normalizer

### DIFF
--- a/header_guard.py
+++ b/header_guard.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+from pathlib import Path
+import argparse
+import re
+from typing import Optional, Tuple
+
+HEADER_EXTS: set[str] = {".h", ".hpp", ".hh", ".hxx", ".inl", ".tpp"}
+LEAD_RE = re.compile(r'^(?:\s*//[^\n]*\n|/\*.*?\*/\s*|\s*\n)+', re.DOTALL)
+PRAGMA_RE = re.compile(r'^\s*#\s*pragma\s+once\s*(?:\r?\n)?', re.IGNORECASE)
+GUARD_START_RE = re.compile(
+    r'^\s*#\s*ifndef\s+([A-Za-z_][A-Za-z0-9_]*)\s*$.*?^\s*#\s*define\s+\1\s*$',
+    re.MULTILINE | re.DOTALL,
+)
+END_RE = re.compile(r'^\s*#\s*endif\b.*(?:\r?\n)?', re.MULTILINE)
+
+
+def is_header_file(p: Path) -> bool:
+    return p.suffix.lower() in HEADER_EXTS
+
+
+def find_repo_root(start: Path) -> Path:
+    for d in [start] + list(start.parents):
+        if (d / ".git").exists():
+            return d
+    return Path(start.anchor or "/")
+
+
+def rel_to_root(root: Path, file: Path) -> Path:
+    try:
+        return file.resolve().relative_to(root.resolve())
+    except Exception:
+        return file.resolve().relative_to(file.anchor)
+
+
+def macro_from_rel_path(rel: Path) -> str:
+    s = str(rel).replace("\\", "/").upper()
+    s = re.sub(r"[^A-Z0-9]+", "_", s).strip("_") + "_"
+    return re.sub(r"_+", "_", s)
+
+
+def leading_comments_span(s: str) -> int:
+    m = LEAD_RE.match(s)
+    return m.end() if m else 0
+
+
+def strip_pragma_once(s: str, i: int) -> Tuple[str, bool]:
+    m = PRAGMA_RE.match(s[i:])
+    return (s[:i] + s[i + m.end():], True) if m else (s, False)
+
+
+def find_guard(s: str) -> Optional[Tuple[int, int, int, int, str]]:
+    m = GUARD_START_RE.search(s)
+    if not m:
+        return None
+    e = list(END_RE.finditer(s, m.end()))
+    return (m.start(), m.end(), e[-1].start(), e[-1].end(), m.group(1)) if e else None
+
+
+def guard_block(m: str) -> str:
+    return f"#ifndef {m}\n#define {m}\n"
+
+
+def end_block(m: str) -> str:
+    return f"#endif  // {m}\n"
+
+
+def insert_guard(s: str, i: int, m: str) -> str:
+    body = s[i:] if s.endswith("\n") else s[i:] + "\n"
+    return s[:i] + guard_block(m) + body + end_block(m)
+
+
+def rebuild_guard(s: str, span: Tuple[int, int, int, int, str], m: str) -> str:
+    a, bs, be, be2, _ = span
+    body = s[bs:be]
+    if body.startswith("\n"): body = body[1:]
+    if not body.endswith("\n"): body += "\n"
+    return s[:a] + guard_block(m) + body + end_block(m) + s[be2:]
+
+
+def process_header_text(s: str, rel_path: str) -> str:
+    macro = macro_from_rel_path(Path(rel_path))
+    i = leading_comments_span(s)
+    s, _ = strip_pragma_once(s, i)
+    g = find_guard(s)
+    return rebuild_guard(s, g, macro) if g else insert_guard(s, i, macro)
+
+
+def _cli_args() -> tuple[Path, Optional[Path]]:
+    ap = argparse.ArgumentParser(description="Normalize C/C++ header guards.")
+    ap.add_argument("path"); ap.add_argument("--root")
+    a = ap.parse_args()
+    return Path(a.path), (Path(a.root) if a.root else None)
+
+
+def run(path: Path, root: Optional[Path]) -> None:
+    if not is_header_file(path): return
+    text = path.read_text(encoding="utf-8")
+    rel = rel_to_root(root or find_repo_root(path), path)
+    new = process_header_text(text, str(rel))
+    if new != text: path.write_text(new, encoding="utf-8")
+
+
+def main() -> int:
+    p, r = _cli_args(); run(p, r); return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "header-guard"
+version = "0.1.0"
+requires-python = ">=3.9"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "-q"

--- a/tests/test_header_guard.py
+++ b/tests/test_header_guard.py
@@ -1,0 +1,177 @@
+import textwrap
+from pathlib import Path
+import pytest
+import header_guard as hg
+
+
+# ---------- Unit tests ----------
+
+def test_is_header_file():
+    assert hg.is_header_file(Path("a.hpp"))
+    assert not hg.is_header_file(Path("a.cpp"))
+
+
+def test_macro_from_rel_path_basic():
+    assert hg.macro_from_rel_path(Path("src/lib/vec3.hpp")) == "SRC_LIB_VEC3_HPP_"
+
+
+def test_macro_from_rel_path_normalizes():
+    p = Path(r"include\\foo+bar/baz qux.hh")
+    assert hg.macro_from_rel_path(p) == "INCLUDE_FOO_BAR_BAZ_QUX_HH_"
+
+
+def test_leading_comments_span_block():
+    s = """/* license */\n\nint x;\n"""
+    assert hg.leading_comments_span(s) > 0
+
+
+def test_leading_comments_span_line_comments():
+    s = "// a\n// b\nint x;\n"
+    assert hg.leading_comments_span(s) == len("// a\n// b\n")
+
+
+def test_strip_pragma_once_at_top():
+    head = "/* h */\n"; body = "#pragma once\nint x;\n"
+    s = head + body
+    out, removed = hg.strip_pragma_once(s, len(head))
+    assert removed and "#pragma once" not in out
+
+
+def test_strip_pragma_once_not_at_lead():
+    s = "int x;\n#pragma once\n"
+    out, removed = hg.strip_pragma_once(s, 0)
+    assert not removed and out == s
+
+
+def test_find_guard_none():
+    assert hg.find_guard("int x;\n") is None
+
+
+def test_find_guard_detects_and_spans():
+    s = textwrap.dedent(
+        """
+        // c
+        #ifndef OLD_GUARD_
+        #define OLD_GUARD_
+        int x;
+        #endif // OLD_GUARD_
+        """
+    )
+    g = hg.find_guard(s)
+    assert g and g[0] < g[1] < g[2] < g[3] and g[4] == "OLD_GUARD_"
+
+
+def test_guard_block_and_end_block():
+    m = "MACRO_"
+    assert hg.guard_block(m) == "#ifndef MACRO_\n#define MACRO_\n"
+    assert hg.end_block(m) == "#endif  // MACRO_\n"
+
+
+def test_insert_guard_shapes_body():
+    body = "int x;\n"
+    out = hg.insert_guard(body, 0, "M_")
+    assert out.startswith("#ifndef M_\n#define M_\n")
+    assert out.rstrip().endswith("#endif  // M_")
+
+
+def test_rebuild_guard_preserves_body():
+    s = textwrap.dedent(
+        """
+        #ifndef A_
+        #define A_
+        int x;\n
+        #endif // A_
+        tail
+        """
+    )
+    g = hg.find_guard(s)
+    out = hg.rebuild_guard(s, g, "B_")
+    assert "#ifndef B_" in out and "A_" not in out
+    assert "int x;\n#endif  // B_" in out and "tail" in out
+
+
+# ---------- Component tests (string-based) ----------
+
+@pytest.mark.parametrize(
+    "rel, src, exp_macro",
+    [
+        (
+            "include/foo/bar.h",
+            "/* hdr */\nint x;\n",
+            "INCLUDE_FOO_BAR_H_",
+        ),
+        (
+            "src/x.hpp",
+            "// hdr\n#pragma once\nint x;\n",
+            "SRC_X_HPP_",
+        ),
+        (
+            "a/b/c.hh",
+            textwrap.dedent(
+                """
+                // top
+                #ifndef WRONG_
+                #define WRONG_
+                int x;
+                #endif
+                """
+            ),
+            "A_B_C_HH_",
+        ),
+    ],
+)
+def test_process_header_text_end_to_end(rel, src, exp_macro):
+    out = hg.process_header_text(src, rel)
+    assert f"#ifndef {exp_macro}\n#define {exp_macro}\n" in out
+    assert out.rstrip().endswith(f"#endif  // {exp_macro}")
+
+
+def test_idempotent_canonical():
+    macro = "SRC_LIB_V_H_"
+    s = f"#ifndef {macro}\n#define {macro}\nint x;\n#endif  // {macro}\n"
+    out = hg.process_header_text(s, "src/lib/v.h")
+    assert out == s
+
+
+def test_mixed_line_endings_windows():
+    s = "#pragma once\r\nint x;\r\n"
+    out = hg.process_header_text(s, "w.h")
+    assert out.count("#pragma once") == 0 and "#ifndef W_H_" in out
+
+
+def test_no_comments_inserts_at_top():
+    out = hg.process_header_text("int x;\n", "a.h")
+    assert out.startswith("#ifndef A_H_\n#define A_H_\n")
+
+
+def test_process_header_text_single_line_comments():
+    s = "// a\n// b\nint x;\n"
+    out = hg.process_header_text(s, "c.h")
+    assert out.startswith("// a\n// b\n#ifndef C_H_\n#define C_H_\n")
+
+
+def test_process_header_text_mixed_separators():
+    rel = r"dir\\sub-dir/file name.tpp"
+    out = hg.process_header_text("int x;\n", rel)
+    assert "#ifndef DIR_SUB_DIR_FILE_NAME_TPP_" in out
+
+
+def test_process_header_text_windows_newline_body_preserved():
+    s = "#ifndef OLD\n#define OLD\r\nbody\r\n#endif\r\n"
+    out = hg.process_header_text(s, "x.h")
+    assert out.count("#ifndef X_H_") == 1
+
+
+def test_no_comments_trailing_newline():
+    out = hg.process_header_text("int x;", "b.h")
+    assert out.endswith("#endif  // B_H_\n")
+
+
+# Optional small I/O smoke test using tmp_path
+
+def test_run_smoke(tmp_path):
+    p = tmp_path / "inc" / "v.hpp"; p.parent.mkdir()
+    p.write_text("#pragma once\nint x;\n", encoding="utf-8")
+    hg.run(p, root=tmp_path)
+    t = p.read_text(encoding="utf-8")
+    assert "#pragma once" not in t and "#ifndef INC_V_HPP_" in t


### PR DESCRIPTION
## Summary
- implement the header guard normalizer module with CLI entrypoints and helper utilities
- add a comprehensive pytest suite covering helper functions and string-based scenarios
- configure pytest discovery through pyproject.toml

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf256e2aa8832a8e0763715d5b7469