### PR TITLE
Add pre-commit tooling and CI gate

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 79
+extend-ignore = E203, W503

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: pre-commit
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-added-large-files
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: debug-statements
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        args: ["--line-length=79"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile=black", "--line-length=79"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/pylint
+    rev: v3.2.3
+    hooks:
+      - id: pylint
+        args: ["--rcfile=.pylintrc"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: ["--config-file", "mypy.ini"]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+ignore=.git
+
+[MESSAGES CONTROL]
+disable=
+    C0114,  # missing-module-docstring
+    C0115,  # missing-class-docstring
+    C0116   # missing-function-docstring
+
+[FORMAT]
+max-line-length=79

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.10
+warn_return_any = True
+warn_unused_configs = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+no_implicit_optional = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 79
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+line_length = 79


### PR DESCRIPTION
## Summary
- add a comprehensive pre-commit configuration with formatting, linting, and type checking hooks
- configure black, flake8, pylint, isort, and mypy to share a 79-character line length
- introduce a GitHub Actions workflow to run the pre-commit suite on pushes and pull requests

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cf3876f934832a9e32d6be327e2525