### PR TITLE
Add configurable spacing before endif comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,25 @@ repos:
 
 The hook rewrites any staged header files so they use the repository-relative
 guard name convention implemented by this tool.
+
+### Configurable spacing
+
+The tool accepts an optional `--spaces-between-endif-and-comment` argument to
+control how many spaces appear between `#endif` and the trailing comment. The
+default is `2`:
+
+```bash
+header-guard --spaces-between-endif-and-comment=1 path/to/header.hpp
+```
+
+When using the tool via pre-commit you can pass the same flag through the hook
+configuration:
+
+```yaml
+repos:
+  - repo: https://github.com/danieldube/cpp_header_guard
+    rev: v0.1.0
+    hooks:
+      - id: header-guard
+        args: ["--spaces-between-endif-and-comment=1"]
+```


### PR DESCRIPTION
## Summary
- add a command line option to configure the spacing between `#endif` and the trailing comment
- propagate the spacing through guard generation so CLI and pre-commit users can customize it
- document the new option for direct usage and pre-commit integration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d86815d978832a95ca9eac60400a08