### PR TITLE
Simplify pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,9 @@
 - id: header-guard
-  name: header-guard
-  description: Ensure C and C++ headers use consistent include guards.
+  name: cpp header guard
+  description: Ensure C/C++ header files have deterministic include guards derived from the repository layout.
   entry: header-guard
   language: python
+  types_or: [c, c++]
   files: '\.(h|hh|hpp|hxx|h\+\+)$'
+  require_serial: true
+  pass_filenames: true


### PR DESCRIPTION
## Summary
- extend the published pre-commit hook metadata so the hook can be consumed without a custom wrapper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daf56fae74832a905d310336966723