### PR TITLE
Fix packaging to include header_guard module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ header-guard = "header_guard:main"
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["header_guard"]
+packages = ["src/header_guard"]
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
## Summary
- ensure the hatch wheel configuration includes the header_guard package so the console script is importable in pre-commit environments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd33fa418c832a9e1aa54dd9adee7a