### PR TITLE
Document header guard pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ The pre-commit hooks reuse the same Hatch-managed environment, so the commands
 above ensure linting and typing run with the dependencies declared in
 `pyproject.toml` and mirrored in `requirements-test.txt`.
 
+## Why a header-guard hook?
+
+Modern compilers support `#pragma once`, but it is a non-standard extension
+that can break down when a header is reachable through multiple filesystem
+paths (for example because of symlinks, generated files, or network shares).
+Traditional include guards avoid these pitfalls because the preprocessor only
+needs to reason about a macro name. Unfortunately, hand-written guards often
+drift: two developers might choose different macro formats, copy-paste from the
+wrong directory, or forget to update the guard when a file moves. Those small
+discrepancies make refactors harder and can even reintroduce multiple-inclusion
+bugs that `#pragma once` was meant to prevent. The pre-commit hook distributed
+with this project standardizes guard names based on the repository layout, so
+every header has a deterministic, portable include guard that survives file
+renames and cross-platform builds.
+
 ## Pre-commit integration
 
 The project publishes a pre-commit hook so repositories can enforce consistent
@@ -39,7 +54,19 @@ repos:
         args: ["--spaces-between-endif-and-comment", "3"]
 ```
 
-The hook rewrites any staged header files so they use the repository-relative
-guard name convention implemented by this tool. The command line interface
-exposes the same `--spaces-between-endif-and-comment` option, allowing you to
-customize how many blanks appear between `#endif` and the trailing comment.
+### Step-by-step usage instructions
+
+1. **Install pre-commit** (once per machine): `pip install pre-commit`.
+2. **Install the hook locally** inside your repository: run
+   `pre-commit install`. This configures Git so the hook runs on every commit.
+3. **(Optional) Run it on demand** for all tracked headers with
+   `pre-commit run header-guard --all-files`.
+4. **Commit as usual.** When you `git commit`, the hook rewrites any staged
+   header files so they use the repository-relative guard name convention
+   implemented by this tool. If it makes changes, the commit will stop so you
+   can review and re-stage the files before retrying. Once all headers conform
+   to the rule, the commit proceeds normally.
+
+The command line interface exposes the same
+`--spaces-between-endif-and-comment` option, allowing you to customize how many
+blanks appear between `#endif` and the trailing comment.


### PR DESCRIPTION
## Summary
- explain why deterministic header guards are preferred over relying on `#pragma once`
- document step-by-step instructions for enabling and running the header-guard pre-commit hook

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dd40ad9e20832a87371f655d895d17