### PR TITLE
Improve CLI argument handling and deduplicate header processing

### DIFF
--- a/src/header_guard/cli.py
+++ b/src/header_guard/cli.py
@@ -47,12 +47,12 @@ CLI = cli
 
 
 def parse_args(argv: Sequence[str]) -> Arguments:
-    """Parse *argv* into :class:`Arguments` without invoking Click's CLI."""
+    """Parse command line arguments without invoking Click's CLI machinery."""
 
-    if not argv:
+    arguments = list(argv)
+    if not arguments:
         raise ValueError("Usage: header-guard <path> [<path> ...]")
 
-    arguments = list(argv[1:])
     try:
         with CLI.make_context("header-guard", arguments) as context:
             paths = tuple(context.params["paths"])


### PR DESCRIPTION
## Summary
- accept CLI arguments without the program name when parsing and invoking the library entry point
- provide clearer repository-root errors, deterministic traversal, and deduplicate header processing
- extend the test suite to cover the new behaviours and guard against regressions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda2ebdf24832ab4d5a3cf5763930d