### PR TITLE
Add system test for pre-commit header guard hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ test = [
     "pytest>=8.0",
     "mypy>=1.10",
     "pylint>=3.2.3",
+    "pre-commit>=3.7",
 ]
 
 [project.scripts]

--- a/tests/test_system_pre_commit.py
+++ b/tests/test_system_pre_commit.py
@@ -2,21 +2,30 @@
 
 from __future__ import annotations
 
+import importlib
 import os
-import shutil
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
-
-import pytest
 
 import header_guard
 
 
-@pytest.mark.skipif(
-    not shutil.which("pre-commit"),
-    reason="pre-commit executable is required for this test",
-)
+def ensure_pre_commit_installed() -> None:
+    """Install the pre-commit package if it is not yet available."""
+
+    try:
+        importlib.import_module("pre_commit")
+    except ModuleNotFoundError:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "pre-commit"],
+            check=True,
+        )
+        importlib.invalidate_caches()
+        importlib.import_module("pre_commit")
+
+
 def test_pre_commit_hook_updates_cpp_header(tmp_path: Path) -> None:
     """Run the published pre-commit hook to rewrite a header guard."""
 
@@ -40,9 +49,19 @@ def test_pre_commit_hook_updates_cpp_header(tmp_path: Path) -> None:
     header.parent.mkdir(parents=True)
     header.write_text("int value;\n", encoding="utf-8")
 
+    ensure_pre_commit_installed()
+
     env = os.environ | {"PRE_COMMIT_HOME": str(repo / ".pre-commit-cache")}
     subprocess.run(
-        ["pre-commit", "run", "header-guard", "--files", str(header)],
+        [
+            sys.executable,
+            "-m",
+            "pre_commit",
+            "run",
+            "header-guard",
+            "--files",
+            str(header),
+        ],
         check=True,
         cwd=repo,
         env=env,

--- a/tests/test_system_pre_commit.py
+++ b/tests/test_system_pre_commit.py
@@ -1,0 +1,55 @@
+"""System test that exercises the pre-commit hook distribution."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import header_guard
+
+
+@pytest.mark.skipif(
+    not shutil.which("pre-commit"),
+    reason="pre-commit executable is required for this test",
+)
+def test_pre_commit_hook_updates_cpp_header(tmp_path: Path) -> None:
+    """Run the published pre-commit hook to rewrite a header guard."""
+
+    repo = tmp_path / "project"
+    repo.mkdir()
+
+    subprocess.run(["git", "init"], check=True, cwd=repo)
+
+    config = textwrap.dedent(
+        """
+        repos:
+          - repo: https://github.com/danieldube/cpp_header_guard
+            rev: main
+            hooks:
+              - id: header-guard
+        """
+    )
+    (repo / ".pre-commit-config.yaml").write_text(config, encoding="utf-8")
+
+    header = repo / "include" / "value.hpp"
+    header.parent.mkdir(parents=True)
+    header.write_text("int value;\n", encoding="utf-8")
+
+    env = os.environ | {"PRE_COMMIT_HOME": str(repo / ".pre-commit-cache")}
+    subprocess.run(
+        ["pre-commit", "run", "header-guard", "--files", str(header)],
+        check=True,
+        cwd=repo,
+        env=env,
+    )
+
+    guard = header_guard.header_guard_name(repo, header)
+    content = header.read_text(encoding="utf-8")
+    assert content.startswith(f"#ifndef {guard}\n#define {guard}\n\n")
+    assert content.rstrip().endswith(f"#endif  // {guard}")
+


### PR DESCRIPTION
## Summary
- add a pytest system test that clones the published pre-commit hook via the repository URL and verifies it rewrites a header guard
- include pre-commit in the test dependency group so the hook can run during CI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda5920ef8832a8eef1da268caa41a